### PR TITLE
Update billing-limits.md

### DIFF
--- a/doc_source/billing-limits.md
+++ b/doc_source/billing-limits.md
@@ -19,7 +19,8 @@ The following table describes the current limits within Billing and Cost Managem
 
 |  |  | 
 | --- |--- |
-| Number of budgets | 2 | 
+| Number of free budgets | 2 | 
+| Total number of budgets per master account | 20,000 | 
 | Characters allowed in a budget name | [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-limits.html) | 
 
 ## Reports<a name="limits-reports"></a>


### PR DESCRIPTION
As per https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html
"Your first two budgets are free of charge."
"You can create up to 20,000 budgets per AWS master account."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
