### PR TITLE
Incorrect Example

### DIFF
--- a/doc_source/billing-permissions-ref.md
+++ b/doc_source/billing-permissions-ref.md
@@ -331,8 +331,8 @@ This policy allows an IAM user to create, view, or delete an AWS Cost and Usage 
         {
             "Effect": "Allow",
             "Action": [
-                "cur:PutReportDefinitions",
-                "cur:DescribeReportDefinition",
+                "cur:PutReportDefinition",
+                "cur:DescribeReportDefinitions",
                 "cur:DeleteReportDefinition"
             ],
             "Resource": [


### PR DESCRIPTION
- Create, view, or delete an AWS Cost and Usage report - had an incorrect example which gave error on trying it.

On verifying it again in IAM docs [1] I see that they should be -

"cur:PutReportDefinition",
"cur:DescribeReportDefinitions",

AND not 

"cur:PutReportDefinitions",
"cur:DescribeReportDefinition",

The "s" at the end is confusing.

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscostandusagereport.html#awscostandusagereport-actions-as-permissions

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
