### PR TITLE
Update billing-reports-costusage-files.md

### DIFF
--- a/doc_source/billing-reports-costusage-files.md
+++ b/doc_source/billing-reports-costusage-files.md
@@ -49,9 +49,9 @@ When you choose to overwrite your previous AWS Cost and Usage report, your AWS C
 For example, your report could be delivered as a collection of the following files\.
 
 ```
-<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>/>-<1>.csv.<zip><
-<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>/>-<2>.csv.<zip><
-<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>/>-<3>.csv.<zip><
+<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>-<1>.csv.<zip>
+<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>-<2>.csv.<zip>
+<example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>-<3>.csv.<zip>
 <example-report-prefix>/<example-report-name>/<example-report-name>/year=2018/month=12/<example-report-name>-Manifest.json
 ```
 


### PR DESCRIPTION
Remove bad markup characters to fix formatting.

Note: master currently doesn't seem to reflect the [published](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-costusage-files.html) version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.