### PR TITLE
Clarification needed on turning on RI Sharing on Member Account

### DIFF
--- a/doc_source/ri-turn-off.md
+++ b/doc_source/ri-turn-off.md
@@ -1,6 +1,6 @@
 # Turning Off Reserved Instance Sharing<a name="ri-turn-off"></a>
 
-The payer account of an organization can turn off Reserved Instance \(RI\) sharing for any accounts in that organization, including the payer account\. This means that Reserved Instances aren't shared between any accounts that have sharing turned off\. To share an RI with an account, both accounts must have sharing turned on\. This preference isn't permanent, and you can change it at any time\. Each estimated bill is computed using the last set of preferences\. The final bill for the month is calculated based on the preferences set at 23:59:59 UTC time on the last day of the month\.
+The payer account of an organization can turn off Reserved Instance \(RI\) sharing for any accounts in that organization, including the payer account\. This means that Reserved Instances aren't shared between any accounts that have sharing turned off\. To share an RI with an account, the payer account must have the RI and Savings Plans discounts sharing turned on to the specific member account\. This preference isn't permanent, and you can change it at any time\. Each estimated bill is computed using the last set of preferences\. The final bill for the month is calculated based on the preferences set at 23:59:59 UTC time on the last day of the month\.
 
 **Important**  
 Turning off RI sharing can result in a higher monthly bill\.


### PR DESCRIPTION
This article says: 
"To share an RI with an account, both accounts must have sharing turned on"


I have a payer and a member account, but I don't see the option to turn on RI Sharing on the member account. I only see this message: "Linked account preferences are managed at the payer account level." It seems to me that you can only control turn on or off the RI sharing to the payer account only. 

I haven't purchased any Reserved Instances on the member account so perhaps, I might be able to see and edit the RI Sharing settings on the member account once I have done this. Yet still, the statement is misleading since you can share your RI by setting it on the payer account alone, without any configuration on the member account. Could you kindly confirm that you really can turn on RI Sharing on the member account?

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
