### PR TITLE
Incorrect description

### DIFF
--- a/doc_source/control-access-billing.md
+++ b/doc_source/control-access-billing.md
@@ -62,7 +62,7 @@ The **Activate IAM Access** setting doesn't control access to the following page
 + The Cost Management view in the AWS Console Mobile Application
 + The Billing and Cost Management SDK APIs \(AWS Cost Explorer, AWS Budgets, and AWS Cost and Usage Reports APIs\)
 
-By default, the **Activate IAM Access** setting is deactivated\. To activate this setting, you must log in to your AWS account using the root user credentials, and then select the setting in the [My Account](https://console.aws.amazon.com/billing/home#/account) page\. Activate this setting in each account where you want to allow IAM user and role access to the Billing and Cost Management console pages\. If you use AWS Organizations, then activate this setting in each management or member account where you want to allow IAM user and role access to the console pages\.
+To activate this setting, you must log in to your AWS account using the root user credentials, and then select the setting in the [My Account](https://console.aws.amazon.com/billing/home#/account) page\. Activate this setting in each account where you want to allow IAM user and role access to the Billing and Cost Management console pages\. If you use AWS Organizations, then activate this setting in each management or member account where you want to allow IAM user and role access to the console pages\.
 
 **Note**  
 The **Activate IAM Access** setting isn't available to IAM users with administrator access\. This setting is available only to the root user of the account\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Incorrect description that Activate IAM access setting is always disabled. It is not. If you create an account with AWS Organizations API and do not specify the parameter, it is set to ALLOW (enabled). I think removing this ambiguous statement is useful plus it does not take away any information fidelity shared on this page. But having this wrong description may lead to sec issues


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
